### PR TITLE
Add SUART and GPS module code

### DIFF
--- a/gps/gps_main.c
+++ b/gps/gps_main.c
@@ -1,0 +1,77 @@
+//
+// Created by Max Leopold on 07/06/2020.
+//
+
+#include "gps_main.h"
+#include "../uart/softuart.h"
+#include "../uart/serial.h"
+
+#include <string.h>
+
+char gps_buf[100];
+char gps_ind;
+char gpgga[] = {'$', 'G', 'P', 'G', 'G', 'A'};
+char gps_string_received;
+char delimiter[] = ",";
+
+void gps_init() {
+    softuart_init();
+}
+
+void gps_main() {
+
+    if (softuart_kbhit()) {
+        char c = softuart_getchar();
+        check_for_coordinates(c);
+    }
+    if (gps_string_received) {
+        gps_string_received = 0;
+        gps_ind = 0;
+        struct gps_coordinates gpsCoordinates = create_gps_coordinates();
+        char str_copy[100];
+        strcpy(str_copy, "Latitude: ");
+        strcat(str_copy, gpsCoordinates.latitude);
+        strcat(str_copy, ", Longitude: ");
+        strcat(str_copy, gpsCoordinates.longitude);
+        strcat(str_copy, ", GMT Time: ");
+        strcat(str_copy, gpsCoordinates.gmt_time);
+        serial_print_line(str_copy);
+        //TODO send data via bluetooth here
+    }
+}
+
+void check_for_coordinates(char c) {
+    gps_buf[gps_ind] = c;
+    gps_ind++;
+
+    if (gps_ind < 7) { // Because of format $GPGGA
+        if (gps_buf[gps_ind - 1] != gpgga[gps_ind - 1]) {
+            gps_ind = 0;
+        }
+    }
+    if (gps_ind >= 50) {
+        gps_string_received = 1;
+    }
+
+}
+
+struct gps_coordinates create_gps_coordinates() {
+    char *ptr;
+    ptr = strtok(gps_buf, delimiter);
+    struct gps_coordinates gpsCoordinates;
+
+    for (int i = 0; i < 5; ++i) {
+        if (i == 1) {
+            gpsCoordinates.gmt_time = ptr;
+        }
+        if (i == 2) {
+            gpsCoordinates.latitude = ptr;
+        }
+        if (i == 4) {
+            gpsCoordinates.longitude = ptr;
+        }
+        ptr = strtok(NULL, delimiter);
+    }
+
+    return gpsCoordinates;
+}

--- a/gps/gps_main.h
+++ b/gps/gps_main.h
@@ -1,0 +1,22 @@
+//
+// Created by Max Leopold on 07/06/2020.
+//
+
+#ifndef ME_BIKE_GPS_MAIN_H
+#define ME_BIKE_GPS_MAIN_H
+
+struct gps_coordinates {
+    char *longitude;
+    char *latitude;
+    char *gmt_time;
+};
+
+void gps_init(void);
+
+void gps_main(void);
+
+void check_for_coordinates(char c);
+
+struct gps_coordinates create_gps_coordinates();
+
+#endif //ME_BIKE_GPS_MAIN_H

--- a/main.c
+++ b/main.c
@@ -1,0 +1,27 @@
+//
+// Created by Max Leopold on 06/06/2020.
+//
+
+#include "main.h"
+#include "uart/serial.h"
+#include "gps/gps_main.h"
+
+#include <avr/interrupt.h>
+
+void init() {
+    serial_init();
+    sei();
+}
+
+
+int main() {
+
+    init();
+
+    gps_init();
+
+    while (1) {
+        gps_main();
+    }
+}
+

--- a/main.h
+++ b/main.h
@@ -1,0 +1,10 @@
+//
+// Created by Max Leopold on 06/06/2020.
+//
+
+#ifndef ME_BIKE_MAIN_H
+#define ME_BIKE_MAIN_H
+
+void init(void);
+
+#endif //ME_BIKE_MAIN_H

--- a/uart/serial.c
+++ b/uart/serial.c
@@ -11,8 +11,10 @@ void serial_init() {
     UBRR0H = UBRRH_VALUE;
     UBRR0L = UBRRL_VALUE;
 
-    UCSR0C = 0x06;       /* Set frame format: 8 bit data, 1 stop bit  */
-    UCSR0B = (1 << TXEN0); /* Enable  transmitter                 */
+    UCSR0C |= (1 << UCSZ01) | (1 << UCSZ00); //Set frame format: 8 bit data, 1 stop bit
+    UCSR0B |= (1 << TXEN0); //enable TX
+    UCSR0B |= (1 << RXEN0); //enable RX
+    UCSR0B |= (1 << RXCIE0); //RX complete interrupt
 }
 
 void serial_print_line(char *str) {

--- a/uart/softuart.c
+++ b/uart/softuart.c
@@ -1,0 +1,275 @@
+// softuart.c
+// AVR-port of the generic software uart written in C
+//
+// Generic code from
+// Colin Gittins, Software Engineer, Halliburton Energy Services
+// (has been available from iar.com web-site -> application notes)
+//
+// Adapted to AVR using avr-gcc and avr-libc
+// by Martin Thomas, Kaiserslautern, Germany
+// <eversmith@heizung-thomas.de>
+// http://www.siwawi.arubi.uni-kl.de/avr_projects
+//
+// AVR-port Version 0.4  10/2010
+//
+// ---------------------------------------------------------------------
+//
+// Remarks from Colin Gittins:
+//
+// Generic software uart written in C, requiring a timer set to 3 times
+// the baud rate, and two software read/write pins for the receive and
+// transmit functions.
+//
+// * Received characters are buffered
+// * putchar(), getchar(), kbhit() and flush_input_buffer() are available
+// * There is a facility for background processing while waiting for input
+// The baud rate can be configured by changing the BAUD_RATE macro as
+// follows:
+//
+// #define BAUD_RATE  19200.0
+//
+// The function init_uart() must be called before any comms can take place
+//
+// Interface routines required:
+// 1. get_rx_pin_status()
+//    Returns 0 or 1 dependent on whether the receive pin is high or low.
+// 2. set_tx_pin_high()
+//    Sets the transmit pin to the high state.
+// 3. set_tx_pin_low()
+//    Sets the transmit pin to the low state.
+// 4. idle()
+//    Background functions to execute while waiting for input.
+// 5. timer_set( BAUD_RATE )
+//    Sets the timer to 3 times the baud rate.
+// 6. set_timer_interrupt( timer_isr )
+//    Enables the timer interrupt.
+//
+// Functions provided:
+// 1. void flush_input_buffer( void )
+//    Clears the contents of the input buffer.
+// 2. char kbhit( void )
+//    Tests whether an input character has been received.
+// 3. char getchar( void )
+//    Reads a character from the input buffer, waiting if necessary.
+// 4. void turn_rx_on( void )
+//    Turns on the receive function.
+// 5. void turn_rx_off( void )
+//    Turns off the receive function.
+// 6. void putchar( char )
+//    Writes a character to the serial port.
+//
+// ---------------------------------------------------------------------
+
+/*
+Remarks by Martin Thomas (avr-gcc/avr-libc):
+V0.1 (2/2005)
+- stdio.h not used
+- AVR-Timer in CTC-Mode ("manual" reload may not be accurate enough)
+- Global Interrupt Flag has to be enabled (see demo-application)
+- Interface timer_set and set_timer_interrupt not used here
+- internal_tx_buffer was defined as unsigned char - thas could not
+  work since more than 8 bits are needed, changed to unsigned short
+- some variables moved from "global scope" into ISR function-scope
+- GPIO initialisation included
+- Added functions for string-output inspired by P. Fleury's AVR UART-lib.
+V0.2 (3/2007)
+- adjusted number of RX-bits
+- adapted to avr-libc ISR-macro (replaces SIGNAL)
+- disable interrupts during timer-init
+- used unsigned char (uint8_t) where apropriate
+- removed "magic" char checking (0xc2)
+- added softuart_can_transmit()
+- Makefile based on template from WinAVR 1/2007
+- reformated
+- extended demo-application to show various methods to
+  send a string from flash and RAM
+- demonstrate usage of avr-libc's stdio in demo-applcation
+- tested with ATmega644 @ 3,6864MHz system-clock using
+  avr-gcc 4.1.1/avr-libc 1.4.5 (WinAVR 1/2007)
+V0.3 (4/2007)
+- better configuration options in softuart.h.
+  ->should be easier to adapt to different AVRs
+- tested with ATtiny85 @ 1MHz (internal RC) with 2400bps
+- AVR-Studio Project-File
+V0.4 (10/2010)
+- added options for ATmega164P, ATmega32P, ATmega64P
+- changed some variable-types from char to unsigned char
+- changed some comparisons from <= to ==
+- small optimization in ISR for RX with temporary variable
+- minor modifications in comments and formating
+- added compiler options -fno-inline-small-functions, -Wl,--relax
+- renamed flag_tx_ready to flag_tx_busy
+- replaced softuart_can_transmit() by softuart_transmit_busy()
+- tested with ATmega324PV @ 1MHz internal RC and 2400bps
+  (options for ATtiny25/45/85 still available)
+- added 3BSD license
+- removed redundant zero-init in declaration of qin and qout
+*/
+
+/* Copyright (c) 2003, Colin Gittins
+   Copyright (c) 2005, 2007, 2010, Martin Thomas
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <avr/pgmspace.h>
+
+#include "softuart.h"
+
+#define SU_TRUE    1
+#define SU_FALSE   0
+
+// startbit and stopbit parsed internally (see ISR)
+#define RX_NUM_OF_BITS (8)
+volatile static char inbuf[SOFTUART_IN_BUF_SIZE];
+volatile static unsigned char qin;
+static unsigned char qout;
+volatile static unsigned char flag_rx_off;
+volatile static unsigned char flag_rx_ready;
+
+#define get_rx_pin_status()    ( SOFTUART_RXPIN  &   ( 1 << SOFTUART_RXBIT ) )
+
+ISR(SOFTUART_T_COMP_LABEL) {
+    static unsigned char flag_rx_waiting_for_stop_bit = SU_FALSE;
+    static unsigned char rx_mask;
+
+    static unsigned char timer_rx_ctr;
+    static unsigned char bits_left_in_rx;
+    static unsigned char internal_rx_buffer;
+
+    unsigned char start_bit, flag_in;
+    unsigned char tmp;
+
+    // Receiver Section
+    if (flag_rx_off == SU_FALSE) {
+        if (flag_rx_waiting_for_stop_bit) {
+            if (--timer_rx_ctr == 0) {
+                flag_rx_waiting_for_stop_bit = SU_FALSE;
+                flag_rx_ready = SU_FALSE;
+                inbuf[qin] = internal_rx_buffer;
+                if (++qin >= SOFTUART_IN_BUF_SIZE) {
+                    // overflow - reset inbuf-index
+                    qin = 0;
+                }
+            }
+        } else {  // rx_test_busy
+            if (flag_rx_ready == SU_FALSE) {
+                start_bit = get_rx_pin_status();
+                // test for start bit
+                if (start_bit == 0) {
+                    flag_rx_ready = SU_TRUE;
+                    internal_rx_buffer = 0;
+                    timer_rx_ctr = 4;
+                    bits_left_in_rx = RX_NUM_OF_BITS;
+                    rx_mask = 1;
+                }
+            } else {  // rx_busy
+                tmp = timer_rx_ctr;
+                if (--tmp == 0) { // if ( --timer_rx_ctr == 0 ) {
+                    // rcv
+                    tmp = 3;
+                    flag_in = get_rx_pin_status();
+                    if (flag_in) {
+                        internal_rx_buffer |= rx_mask;
+                    }
+                    rx_mask <<= 1;
+                    if (--bits_left_in_rx == 0) {
+                        flag_rx_waiting_for_stop_bit = SU_TRUE;
+                    }
+                }
+                timer_rx_ctr = tmp;
+            }
+        }
+    }
+}
+
+static void io_init(void) {
+    // RX-Pin as input
+    SOFTUART_RXDDR &= ~(1 << SOFTUART_RXBIT);
+}
+
+static void timer_init(void) {
+    unsigned char sreg_tmp;
+
+    sreg_tmp = SREG;
+    cli();
+
+    SOFTUART_T_COMP_REG = SOFTUART_TIMERTOP;     /* set top */
+
+    SOFTUART_T_CONTR_REGA = SOFTUART_CTC_MASKA | SOFTUART_PRESC_MASKA;
+    SOFTUART_T_CONTR_REGB = SOFTUART_CTC_MASKB | SOFTUART_PRESC_MASKB;
+
+    SOFTUART_T_INTCTL_REG |= SOFTUART_CMPINT_EN_MASK;
+
+    SOFTUART_T_CNT_REG = 0; /* reset counter */
+
+    SREG = sreg_tmp;
+}
+
+void softuart_init(void) {
+    flag_rx_ready = SU_FALSE;
+    flag_rx_off = SU_FALSE;
+
+    io_init();
+    timer_init();
+}
+
+static void idle(void) {
+    // timeout handling goes here
+    // - but there is a "softuart_kbhit" in this code...
+    // add watchdog-reset here if needed
+}
+
+void softuart_turn_rx_on(void) {
+    flag_rx_off = SU_FALSE;
+}
+
+void softuart_turn_rx_off(void) {
+    flag_rx_off = SU_TRUE;
+}
+
+char softuart_getchar(void) {
+    char ch;
+
+    while (qout == qin) {
+        idle();
+    }
+    ch = inbuf[qout];
+    if (++qout >= SOFTUART_IN_BUF_SIZE) {
+        qout = 0;
+    }
+
+    return (ch);
+}
+
+unsigned char softuart_kbhit(void) {
+    return (qin != qout);
+}
+
+void softuart_flush_input_buffer(void) {
+    qin = 0;
+    qout = 0;
+}

--- a/uart/softuart.h
+++ b/uart/softuart.h
@@ -1,0 +1,104 @@
+#if !defined(F_CPU)
+#warning "F_CPU not defined in makefile - now defined in softuart.h"
+#define F_CPU 16000000UL
+#endif
+
+#define SOFTUART_BAUD_RATE      9600
+
+#if defined (__AVR_ATtiny25__) || defined (__AVR_ATtiny45__) || defined (__AVR_ATtiny85__)
+#define SOFTUART_RXPIN   PINB
+#define SOFTUART_RXDDR   DDRB
+#define SOFTUART_RXBIT   PB0
+
+#define SOFTUART_T_COMP_LABEL      TIM0_COMPA_vect
+#define SOFTUART_T_COMP_REG        OCR0A
+#define SOFTUART_T_CONTR_REGA      TCCR0A
+#define SOFTUART_T_CONTR_REGB      TCCR0B
+#define SOFTUART_T_CNT_REG         TCNT0
+#define SOFTUART_T_INTCTL_REG      TIMSK
+
+#define SOFTUART_CMPINT_EN_MASK    (1 << OCIE0A)
+
+#define SOFTUART_CTC_MASKA         (1 << WGM01)
+#define SOFTUART_CTC_MASKB         (0)
+
+/* "A timer interrupt must be set to interrupt at three times
+   the required baud rate." */
+#define SOFTUART_PRESCALE (8)
+// #define SOFTUART_PRESCALE (1)
+
+#if (SOFTUART_PRESCALE == 8)
+#define SOFTUART_PRESC_MASKA         (0)
+#define SOFTUART_PRESC_MASKB         (1 << CS01)
+#elif (SOFTUART_PRESCALE==1)
+#define SOFTUART_PRESC_MASKA         (0)
+#define SOFTUART_PRESC_MASKB         (1 << CS00)
+#else
+#error "prescale unsupported"
+#endif
+#elif defined (__AVR_ATmega324P__) || defined (__AVR_ATmega324A__)  \
+ || defined (__AVR_ATmega644P__) || defined (__AVR_ATmega644PA__) \
+ || defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328PA__) \
+ || defined (__AVR_ATmega164P__) || defined (__AVR_ATmega164A__)
+
+#define SOFTUART_RXPIN   PINB
+#define SOFTUART_RXDDR   DDRB
+#define SOFTUART_RXBIT   PB0
+
+#define SOFTUART_T_COMP_LABEL      TIMER0_COMPA_vect
+#define SOFTUART_T_COMP_REG        OCR0A
+#define SOFTUART_T_CONTR_REGA      TCCR0A
+#define SOFTUART_T_CONTR_REGB      TCCR0B
+#define SOFTUART_T_CNT_REG         TCNT0
+#define SOFTUART_T_INTCTL_REG      TIMSK0
+#define SOFTUART_CMPINT_EN_MASK    (1 << OCIE0A)
+#define SOFTUART_CTC_MASKA         (1 << WGM01)
+#define SOFTUART_CTC_MASKB         (0)
+
+/* "A timer interrupt must be set to interrupt at three times
+   the required baud rate." */
+#define SOFTUART_PRESCALE (8)
+// #define SOFTUART_PRESCALE (1)
+
+#if (SOFTUART_PRESCALE == 8)
+#define SOFTUART_PRESC_MASKA         (0)
+#define SOFTUART_PRESC_MASKB         (1 << CS01)
+#elif (SOFTUART_PRESCALE == 1)
+#define SOFTUART_PRESC_MASKA         (0)
+#define SOFTUART_PRESC_MASKB         (1 << CS00)
+#else
+#error "prescale unsupported"
+#endif
+#else
+#error "no defintions available for this AVR"
+#endif
+
+#define SOFTUART_TIMERTOP ( F_CPU/SOFTUART_PRESCALE/SOFTUART_BAUD_RATE/3 - 1)
+
+#if (SOFTUART_TIMERTOP > 0xff)
+#warning "Check SOFTUART_TIMERTOP: increase prescaler, lower F_CPU or use a 16 bit timer"
+#endif
+
+#define SOFTUART_IN_BUF_SIZE     32
+
+// Init the Software Uart
+void softuart_init(void);
+
+// Clears the contents of the input buffer.
+void softuart_flush_input_buffer(void);
+
+// Tests whether an input character has been received.
+unsigned char softuart_kbhit(void);
+
+// Reads a character from the input buffer, waiting if necessary.
+char softuart_getchar(void);
+
+// Turns on the receive function.
+void softuart_turn_rx_on(void);
+
+// Turns off the receive function.
+void softuart_turn_rx_off(void);
+
+// Helper-Macro - "automatically" inserts PSTR
+// when used: include avr/pgmspace.h before this include-file
+#define softuart_puts_P(s___) softuart_puts_p(PSTR(s___))


### PR DESCRIPTION
SUART is a library I used. 
I cant use the normal UART pins, because @flow96 will use them for the bluetooth sensor. SUART stands for Softwre-UART and is imitating a UART RX/TX Pin on a normal PIN. It is quite hard to implement and needs a lot of knowledge, so I used a library file that I modified quite heavily and removed all (for me) unneccesarry code. With this new SUART file I can use PIN B 0 (Arduino Digital Pin 8) as a UART RX PIN.

The GPS Sensor sends data via UART in the following format:
`$GPGGA,141848.00,2237.63306,N,08820.86316,E,1,03,2.56,1.9,M,-54.2,M,,*74`:
1. $ -> Identifier
2. GPGGA -> Global Positioning System Fix Data
3. 141848.00 -> GMT Time 14:18:48:00
4. 2237.63306,N -> Latitude
5. 08820.86316,E -> Longitude

We only need those five values, the rest can be safely ignored.

Until we dont have a Bluetooth interface I just printed all the values to the console. As soon as we got a bluetooth interface I will send the `gps_coordinates` struct via bluetooth to the smartphone application. 